### PR TITLE
change createLoadBalancerRule to create corresponding firewall rules

### DIFF
--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -724,7 +724,7 @@ func (lb *loadBalancer) createLoadBalancerRule(lbRuleName string, ports []v1.Ser
 	}
 
 	// Do not create corresponding firewall rule.
-	p.SetParam("openfirewall", false)
+	p.SetParam("openfirewall", true)
 
 	// Create a new load balancer rule.
 	r := cloudstack.CreateLoadBalancerRuleResponse{}


### PR DESCRIPTION
The current loadbalancer implementation in cloudstack doesn't create the corresponding firewall rules. So you would need to create the firewall rules manually in Cloudstack, which shouldn't be the case in my opinion. 