### PR TITLE
cloudstack/loadbalancer: fix erroneous multiple returned values for LB rules find

### DIFF
--- a/cloudstack/fake/cloudstack.go
+++ b/cloudstack/fake/cloudstack.go
@@ -69,6 +69,10 @@ func (s *CloudstackServer) AddIP(ip cloudstack.PublicIpAddress) {
 	s.ips[ip.Id] = &ip
 }
 
+func (s *CloudstackServer) AddLBRule(lbName string, lbRule loadBalancerRule) {
+	s.lbRules[lbName] = lbRule
+}
+
 func (s *CloudstackServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cmd := r.FormValue("command")
 	s.Calls = append(s.Calls, MockAPICall{
@@ -86,7 +90,7 @@ func (s *CloudstackServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		keyword := r.FormValue("keyword")
 		var lbs []loadBalancerRule
 		for _, lb := range s.lbRules {
-			if lb["name"] == keyword || lb["id"] == keyword {
+			if strings.Contains(lb["name"].(string), keyword) || strings.Contains(lb["id"].(string), keyword) {
 				lb["tags"] = s.tags[lb["id"].(string)]
 				lbs = append(lbs, lb)
 			}

--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -346,19 +346,26 @@ func getLoadBalancerRule(client *cloudstack.CloudStackClient, lbName, projectID 
 		Count             int                 `json:"count"`
 		LoadBalancerRules []*loadBalancerRule `json:"loadbalancerrule"`
 	}
+	var lbResult *loadBalancerRule
 
 	err := client.Custom.CustomRequest("listLoadBalancerRules", pc, &result)
 	if err != nil {
 		return nil, err
 	}
-	if result.Count > 1 {
-		return nil, fmt.Errorf("lb %q too many rules associated: %#v", lbName, result.LoadBalancerRules)
-	}
 	if result.Count == 0 {
 		return nil, nil
 	}
-
-	return result.LoadBalancerRules[0], nil
+	count := 0
+	for idx := range result.LoadBalancerRules {
+		if result.LoadBalancerRules[idx].Name == lbName {
+			lbResult = result.LoadBalancerRules[idx]
+			count++
+		}
+	}
+	if count > 1 {
+		return nil, fmt.Errorf("lb %q too many rules associated: %#v", lbName, result.LoadBalancerRules)
+	}
+	return lbResult, nil
 }
 
 // extractIDs extracts the VM ID for each node, their unique network IDs and project ID

--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -365,6 +365,9 @@ func getLoadBalancerRule(client *cloudstack.CloudStackClient, lbName, projectID 
 	if count > 1 {
 		return nil, fmt.Errorf("lb %q too many rules associated: %#v", lbName, result.LoadBalancerRules)
 	}
+	if count == 0 {
+		return nil, nil
+	}
 	return lbResult, nil
 }
 

--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -346,7 +346,6 @@ func getLoadBalancerRule(client *cloudstack.CloudStackClient, lbName, projectID 
 		Count             int                 `json:"count"`
 		LoadBalancerRules []*loadBalancerRule `json:"loadbalancerrule"`
 	}
-	var lbResult *loadBalancerRule
 
 	err := client.Custom.CustomRequest("listLoadBalancerRules", pc, &result)
 	if err != nil {
@@ -355,10 +354,13 @@ func getLoadBalancerRule(client *cloudstack.CloudStackClient, lbName, projectID 
 	if result.Count == 0 {
 		return nil, nil
 	}
-	count := 0
-	for idx := range result.LoadBalancerRules {
-		if result.LoadBalancerRules[idx].Name == lbName {
-			lbResult = result.LoadBalancerRules[idx]
+
+	var count int
+	var lbResult *loadBalancerRule
+
+	for _, lbRule := range result.LoadBalancerRules {
+		if lbRule.Name == lbName {
+			lbResult = lbRule
 			count++
 		}
 	}

--- a/cloudstack/loadbalancer_test.go
+++ b/cloudstack/loadbalancer_test.go
@@ -179,6 +179,66 @@ func Test_CSCloud_EnsureLoadBalancer(t *testing.T) {
 		},
 
 		{
+			name: "updating ports while returned multiple lb rules with same suffix lbname",
+			hook: func(t *testing.T, srv *cloudstackFake.CloudstackServer) {
+				srv.AddLBRule("foo.svc1.test.com", map[string]interface{}{
+					"id":         "foo.svc1.test.com",
+					"name":       "foo.svc1.test.com",
+					"publicip":   "10.0.0.2",
+					"publicipid": "foo.svc1.test.com",
+					"networkid":  "1234",
+				})
+				srv.AddLBRule("bar.svc1.test.com", map[string]interface{}{
+					"id":         "bar.svc1.test.com",
+					"name":       "bar.svc1.test.com",
+					"publicip":   "10.0.0.3",
+					"publicipid": "bar.svc1.test.com",
+					"networkid":  "5678",
+				})
+			},
+			calls: []consecutiveCall{
+				{
+					svc:    baseSvc,
+					assert: baseAssert,
+				},
+				{
+					svc: (func() corev1.Service {
+						svc := baseSvc.DeepCopy()
+						svc.Spec.Ports[0].NodePort = 30003
+						return *svc
+					})(),
+					assert: func(t *testing.T, srv *cloudstackFake.CloudstackServer, lbStatus *v1.LoadBalancerStatus, err error) {
+						require.NoError(t, err)
+						assert.Equal(t, lbStatus, &corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{
+								{IP: "10.0.0.1", Hostname: "svc1.test.com"},
+							},
+						})
+						srv.HasCalls(t, []cloudstackFake.MockAPICall{
+							{Command: "listVirtualMachines"},
+							{Command: "listLoadBalancerRules", Params: url.Values{"keyword": []string{"svc1.test.com"}}},
+							{Command: "deleteLoadBalancerRule", Params: url.Values{"id": []string{"lbrule-1"}}},
+							{Command: "queryAsyncJobResult"},
+							{Command: "createLoadBalancerRule", Params: url.Values{"name": []string{"svc1.test.com"}, "publicipid": []string{"ip-1"}, "privateport": []string{"30003"}}},
+							{Command: "queryAsyncJobResult"},
+							{Command: "createTags", Params: url.Values{"tags[0].key": []string{"cloudprovider"}, "tags[0].value": []string{"custom-cloudstack"}}},
+							{Command: "queryAsyncJobResult"},
+							{Command: "createTags", Params: url.Values{"tags[0].key": []string{"kubernetes_namespace"}, "tags[0].value": []string{"myns"}}},
+							{Command: "queryAsyncJobResult"},
+							{Command: "createTags", Params: url.Values{"tags[0].key": []string{"kubernetes_service"}, "tags[0].value": []string{"svc1"}}},
+							{Command: "queryAsyncJobResult"},
+							{Command: "listLoadBalancerRuleInstances", Params: url.Values{"page": []string{"0"}, "id": []string{"lbrule-2"}}},
+							{Command: "assignNetworkToLBRule", Params: url.Values{"id": []string{"lbrule-2"}, "networkids": []string{"net1"}}},
+							{Command: "queryAsyncJobResult"},
+							{Command: "assignToLoadBalancerRule", Params: url.Values{"id": []string{"lbrule-2"}, "virtualmachineids": []string{"vm1"}}},
+							{Command: "queryAsyncJobResult"},
+						})
+					},
+				},
+			},
+		},
+
+		{
 			name: "create load balancer error",
 			hook: func(t *testing.T, srv *cloudstackFake.CloudstackServer) {
 				calls := 0


### PR DESCRIPTION
Using keyword option for any cloudstack api call always returns values matching keyword as substring instead exact match. This PR checks for LB rule name for exact match and fixes multiple returned values error. 