### PR TITLE
feat(loadbalancer): support turn on/off LB removal by service labels

### DIFF
--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -44,7 +44,7 @@ const (
 	lbCustomHealthCheckMessagePrefix   = "csccm.cloudprovider.io/loadbalancer-custom-healthcheck-msg-"
 	lbCustomHealthCheckResponsePrefix  = "csccm.cloudprovider.io/loadbalancer-custom-healthcheck-rsp-"
 
-	removeLBsOnRemoveLabelKey = "csccm.cloudprovider.io/remove-loadbalancers-on-remove"
+	removeLBsOnDeleteLabelKey = "csccm.cloudprovider.io/remove-loadbalancers-on-delete"
 
 	cloudProviderTag = "cloudprovider"
 	serviceTag       = "kubernetes_service"
@@ -325,7 +325,7 @@ func (cs *CSCloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName st
 func isLBRemovalEnabled(lb *loadBalancer, service *v1.Service) bool {
 	klog.V(5).Infof("isLBRemovalEnabled(%v, %v, %v)", lb.ip, service.Namespace, service.Name)
 
-	if removeLBFlag, ok := getLabelOrAnnotation(service.ObjectMeta, removeLBsOnRemoveLabelKey); ok {
+	if removeLBFlag, ok := getLabelOrAnnotation(service.ObjectMeta, removeLBsOnDeleteLabelKey); ok {
 		klog.V(5).Infof("LB removal flag %q has been found on %q Service labels/annotations", removeLBFlag, service)
 		if b, err := strconv.ParseBool(removeLBFlag); err == nil {
 			return b

--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -290,13 +290,13 @@ func (cs *CSCloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName st
 		return nil
 	}
 
-	if !shouldManageLB(lb, service) {
-		klog.V(3).Infof("Skipping EnsureLoadBalancerDeleted for service %s/%s and LB %q", service.Namespace, service.Name, lb.ip)
+	if lb.rule == nil {
+		klog.V(3).Infof("Skipping EnsureLoadBalancerDeleted; LoadBalancerRule not found for service %s/%s", service.Namespace, service.Name)
 		return nil
 	}
 
-	if lb.rule == nil {
-		klog.V(3).Infof("Skipping EnsureLoadBalancerDeleted; LBRule not found for service %s/%s and LB %q", service.Namespace, service.Name, lb.ip)
+	if !shouldManageLB(lb, service) {
+		klog.V(3).Infof("Skipping EnsureLoadBalancerDeleted for service %s/%s and LB %q", service.Namespace, service.Name, lb.ip)
 		return nil
 	}
 

--- a/cloudstack/loadbalancer_test.go
+++ b/cloudstack/loadbalancer_test.go
@@ -1444,7 +1444,7 @@ func Test_CSCloud_EnsureLoadBalancerDeleted(t *testing.T) {
 			name: "lb removal is enabled on service labels; lb rules without mandatory resource tags; should not manage",
 			svc: func() *corev1.Service {
 				svc := baseSvc.DeepCopy()
-				svc.Annotations["csccm.cloudprovider.io/remove-loadbalancers-on-remove"] = "true"
+				svc.Annotations["csccm.cloudprovider.io/remove-loadbalancers-on-delete"] = "true"
 				return svc
 			}(),
 			setup: func(cs *cloudstackFake.CloudstackServer) {
@@ -1469,7 +1469,7 @@ func Test_CSCloud_EnsureLoadBalancerDeleted(t *testing.T) {
 			svc: func() *corev1.Service {
 				svc := baseSvc.DeepCopy()
 				svc.Annotations["environment-label"] = "env2"
-				svc.Annotations["csccm.cloudprovider.io/remove-loadbalancers-on-remove"] = "false"
+				svc.Annotations["csccm.cloudprovider.io/remove-loadbalancers-on-delete"] = "false"
 				return svc
 			}(),
 			setup: func(cs *cloudstackFake.CloudstackServer) {
@@ -1498,7 +1498,7 @@ func Test_CSCloud_EnsureLoadBalancerDeleted(t *testing.T) {
 			name: "lb removal enabled on service labels and lb managed by this controller (custom-cloudstack)",
 			svc: func() *corev1.Service {
 				svc := baseSvc.DeepCopy()
-				svc.Annotations["csccm.cloudprovider.io/remove-loadbalancers-on-remove"] = "true"
+				svc.Annotations["csccm.cloudprovider.io/remove-loadbalancers-on-delete"] = "true"
 				return svc
 			}(),
 			setup: func(cs *cloudstackFake.CloudstackServer) {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
-	github.com/xanzy/go-cloudstack/v2 v2.8.0
+	github.com/xanzy/go-cloudstack/v2 v2.8.1-0.20200331213729-bc6cdc7c37e5
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.3 // indirect
 	golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56 // indirect

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/vmware/govmomi v0.20.1/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59b
 github.com/vmware/photon-controller-go-sdk v0.0.0-20170310013346-4a435daef6cc/go.mod h1:e6humHha1ekIwTCm+A5Qed5mG8V4JL+ChHcUOJ+L/8U=
 github.com/xanzy/go-cloudstack v0.0.0-20160728180336-1e2cbf647e57 h1:3OK6oXqbbEUeWvTJgg1pZgNjzdCNE6hMu2TragCfwb8=
 github.com/xanzy/go-cloudstack v0.0.0-20160728180336-1e2cbf647e57/go.mod h1:s3eL3z5pNXF5FVybcT+LIVdId8pYn709yv6v5mrkrQE=
-github.com/xanzy/go-cloudstack/v2 v2.8.0 h1:fT6EK104RkcSpGrdlsrFZbCFob3vyXeXm60HUYtouU4=
-github.com/xanzy/go-cloudstack/v2 v2.8.0/go.mod h1:+SiI2stR3n/P6IKCjrlD2e2EWzk+rQqK4SxC4V9QhnY=
+github.com/xanzy/go-cloudstack/v2 v2.8.1-0.20200331213729-bc6cdc7c37e5 h1:p3db12oBLLOzULsCenBqAKWq2L50g2JfSokX52+bV0M=
+github.com/xanzy/go-cloudstack/v2 v2.8.1-0.20200331213729-bc6cdc7c37e5/go.mod h1:+SiI2stR3n/P6IKCjrlD2e2EWzk+rQqK4SxC4V9QhnY=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
This PR introduces a new label/annotation  (`csccm.cloudprovider.io/remove-loadbalancers-on-delete`) on Service resource that indicates it wants enable/disable the related LoadBalancer removal. Its value should be a valid boolean (see accepted values in https://pkg.go.dev/strconv?tab=doc#ParseBool).


If set, this configuration has precedence over the environment configuration.

Usage:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: my-service
  annotations:
    csccm.cloudprovider.io/remove-loadbalancers-on-delete: "true"
    ...
```