### PR TITLE
WIP: Allow default project-id and environment

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -44,3 +44,7 @@ jobs:
     - name: push latest to docker
       if: contains(github.ref, 'refs/heads/master')
       run: make push
+    
+    - name: push branch to docker
+      if: startsWith(github.ref, 'refs/heads/')
+      run: make TAG=${GITHUB_REF/refs\/heads\//} push

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -64,6 +64,7 @@ type environmentConfig struct {
 	SecretKey       string `gcfg:"secret-key"`
 	LBEnvironmentID string `gcfg:"lb-environment-id"`
 	LBDomain        string `gcfg:"lb-domain"`
+	ProjectID       string `gcfg:"project-id"`
 	SSLNoVerify     bool   `gcfg:"ssl-no-verify"`
 	RemoveLBs       bool   `gcfg:"remove-lbs-on-delete"`
 }


### PR DESCRIPTION
This change makes it easier to use this provider when the entire cluster is using a single cloudstack project in a single cloudstack enviroment.

The environment and project id labels in each node are no longer required in this situation.