### PR TITLE
Use worker queue to update multiple services in parallel

### DIFF
--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/transport"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
 )
 
 // ProviderName is the name of this cloud provider.
@@ -220,6 +221,7 @@ func newCSCloud(cfg *CSConfig) (*CSCloud, error) {
 func (cs *CSCloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	cs.kubeClient = clientBuilder.ClientOrDie(ProviderName)
 	b := record.NewBroadcaster()
+	b.StartLogging(klog.Infof)
 	b.StartRecordingToSink(&typedcore.EventSinkImpl{Interface: typedcore.New(cs.kubeClient.CoreV1().RESTClient()).Events("")})
 	cs.recorder = b.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "csccm"})
 

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -119,7 +119,7 @@ type CSCloud struct {
 	environments  map[string]CSEnvironment
 	kubeClient    kubernetes.Interface
 	recorder      record.EventRecorder
-	updateLBQueue *serviceNodeQueue
+	updateLBQueue *updateLBNodeQueue
 	nodeRegistry  *nodeRegistry
 	config        CSConfig
 

--- a/cloudstack/fake/cloudstack.go
+++ b/cloudstack/fake/cloudstack.go
@@ -40,7 +40,7 @@ type globoNetworkPool struct {
 	VipPort             int    `json:"vipport"`
 	HealthCheckType     string `json:"healthchecktype"`
 	HealthCheck         string `json:"healthcheck"`
-	HealthCheckExpected string `json:"healthcheckexpected"`
+	HealthCheckExpected string `json:"healthcheckexpect"`
 	Id                  int    `json:"id"`
 }
 

--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/xanzy/go-cloudstack/v2/cloudstack"
 	v1 "k8s.io/api/core/v1"
@@ -305,7 +306,10 @@ func (cs *CSCloud) UpdateLoadBalancer(ctx context.Context, clusterName string, s
 		return err
 	}
 
-	return cs.updateLBQueue.upsert(service)
+	return cs.updateLBQueue.push(queueEntry{
+		service: service,
+		start:   time.Now(),
+	})
 }
 
 // EnsureLoadBalancerDeleted deletes the specified load balancer if it exists, returning

--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -192,7 +192,7 @@ func (cs *CSCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, s
 		return nil, err
 	}
 
-	hostIDs, networkIDs, projectID, err := cs.nodeRegistry.idsForService(service)
+	_, networkIDs, projectID, err := cs.nodeRegistry.idsForService(service)
 	if err != nil {
 		return nil, err
 	}
@@ -282,11 +282,13 @@ func (cs *CSCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, s
 		}
 	}
 
-	if err = lb.syncNodes(hostIDs, networkIDs); err != nil {
-		return nil, err
-	}
-
-	if err = lb.updateLoadBalancerPool(); err != nil {
+	err = cs.updateLBQueue.push(queueEntry{
+		service:    service,
+		lb:         lb,
+		start:      time.Now(),
+		updatePool: true,
+	})
+	if err != nil {
 		return nil, err
 	}
 

--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -146,7 +146,7 @@ func (cs *CSCloud) GetLoadBalancer(ctx context.Context, clusterName string, serv
 		return nil, false, fmt.Errorf("GetLoadBalancer: service cannot be nil")
 	}
 
-	klog.V(5).Infof("GetLoadBalancer(%v, %v, %v)", clusterName, service.Namespace, service.Name)
+	klog.V(4).Infof("GetLoadBalancer(%v, %v, %v)", clusterName, service.Namespace, service.Name)
 	cs.svcLock.Lock(service)
 	defer cs.svcLock.Unlock(service)
 
@@ -178,7 +178,7 @@ func (cs *CSCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, s
 		return nil, fmt.Errorf("EnsureLoadBalancer: service cannot be nil")
 	}
 
-	klog.V(5).Infof("EnsureLoadBalancer(%v, %v, %v, %v, ports: %d, nodes: %d)", clusterName, service.Namespace, service.Name, service.Spec.LoadBalancerIP, len(service.Spec.Ports), len(nodes))
+	klog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, ports: %d, nodes: %d)", clusterName, service.Namespace, service.Name, service.Spec.LoadBalancerIP, len(service.Spec.Ports), len(nodes))
 	cs.svcLock.Lock(service)
 	defer cs.svcLock.Unlock(service)
 
@@ -298,7 +298,7 @@ func (cs *CSCloud) UpdateLoadBalancer(ctx context.Context, clusterName string, s
 		return fmt.Errorf("UpdateLoadBalancer: service cannot be nil")
 	}
 
-	klog.V(5).Infof("UpdateLoadBalancer(%v, %v, %v, %#v)", clusterName, service.Namespace, service.Name, nodes)
+	klog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v, %#v)", clusterName, service.Namespace, service.Name, nodes)
 
 	err := cs.nodeRegistry.updateNodes(nodes)
 	if err != nil {
@@ -315,7 +315,7 @@ func (cs *CSCloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName st
 		return fmt.Errorf("EnsureLoadBalancerDeleted: service cannot be nil")
 	}
 
-	klog.V(5).Infof("EnsureLoadBalancerDeleted(%v, %v, %v)", clusterName, service.Namespace, service.Name)
+	klog.V(4).Infof("EnsureLoadBalancerDeleted(%v, %v, %v)", clusterName, service.Namespace, service.Name)
 	cs.svcLock.Lock(service)
 	defer cs.svcLock.Unlock(service)
 
@@ -359,16 +359,16 @@ func (cs *CSCloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName st
 // isLBRemovalEnabled indicates whether the configurations for load balancer
 // removal is enabled.
 func isLBRemovalEnabled(lb *loadBalancer, service *v1.Service) bool {
-	klog.V(5).Infof("isLBRemovalEnabled(%v, %v, %v)", lb, service.Namespace, service.Name)
+	klog.V(4).Infof("isLBRemovalEnabled(%v, %v, %v)", lb, service.Namespace, service.Name)
 
 	if removeLBFlag, ok := getLabelOrAnnotation(service.ObjectMeta, removeLBsOnDeleteLabelKey); ok {
-		klog.V(5).Infof("LB removal flag %q has been found on %q Service labels/annotations", removeLBFlag, service)
+		klog.V(4).Infof("LB removal flag %q has been found on %q Service labels/annotations", removeLBFlag, service)
 		if b, err := strconv.ParseBool(removeLBFlag); err == nil {
 			return b
 		}
 	}
 
-	klog.V(5).Infof("checking whether the LB removal is enabled for the %q environment", lb.cloud.environment)
+	klog.V(4).Infof("checking whether the LB removal is enabled for the %q environment", lb.cloud.environment)
 	return lb.cloud.environments[lb.cloud.environment].removeLBs
 }
 

--- a/cloudstack/loadbalancer.go
+++ b/cloudstack/loadbalancer.go
@@ -93,7 +93,7 @@ type globoNetworkPool struct {
 	VipPort             int    `json:"vipport"`
 	HealthCheckType     string `json:"healthchecktype"`
 	HealthCheck         string `json:"healthcheck"`
-	HealthCheckExpected string `json:"healthcheckexpected"`
+	HealthCheckExpected string `json:"healthcheckexpect"`
 	Id                  int    `json:"id"`
 }
 

--- a/cloudstack/loadbalancer_test.go
+++ b/cloudstack/loadbalancer_test.go
@@ -2262,6 +2262,10 @@ func Test_CSCloud_EnsureLoadBalancer(t *testing.T) {
 					cc.assertSvc(t, clusterSvc)
 				}
 				srv.Calls = nil
+
+				// flush pending calls
+				csCloud.updateLBQueue.start(context.Background())
+				csCloud.updateLBQueue.stopWait()
 			}
 		})
 	}

--- a/cloudstack/nodes.go
+++ b/cloudstack/nodes.go
@@ -1,0 +1,271 @@
+package cloudstack
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+)
+
+type nodeInfo struct {
+	name          string
+	vmID          string
+	networkID     string
+	hostName      string
+	projectID     string
+	environmentID string
+	filterValue   string
+	revision      uint64
+}
+
+type nodeRegistry struct {
+	nodes      map[string]*nodeInfo
+	nodesMu    sync.RWMutex
+	svcNodes   map[serviceKey]sets.String
+	svcNodesMu sync.RWMutex
+	cs         *CSCloud
+	revision   uint64
+}
+
+func newNodeRegistry(cs *CSCloud) *nodeRegistry {
+	return &nodeRegistry{
+		nodes:    map[string]*nodeInfo{},
+		cs:       cs,
+		revision: 0,
+	}
+}
+
+func (r *nodeRegistry) nodesContainingService(svcKey serviceKey) []nodeInfo {
+	r.nodesMu.RLock()
+	defer r.nodesMu.RUnlock()
+	r.svcNodesMu.RLock()
+	defer r.svcNodesMu.RUnlock()
+
+	var nodes []nodeInfo
+
+	svcNodes := r.svcNodes[svcKey]
+	for nodeName := range svcNodes {
+		node := r.nodes[nodeName]
+		nodes = append(nodes, *node)
+	}
+
+	return nodes
+}
+
+func (r *nodeRegistry) updateEndpointsNodes(endpoints *v1.Endpoints) {
+	r.svcNodesMu.Lock()
+	defer r.svcNodesMu.Unlock()
+
+	key := serviceKey{namespace: endpoints.Namespace, name: endpoints.Name}
+	r.svcNodes[key] = sets.String{}
+
+	for _, subset := range endpoints.Subsets {
+		for _, addr := range subset.Addresses {
+			if addr.NodeName == nil {
+				continue
+			}
+			r.svcNodes[key].Insert(*addr.NodeName)
+		}
+	}
+}
+
+func (r *nodeRegistry) deleteEndpointsNodes(endpoints *v1.Endpoints) {
+	r.svcNodesMu.Lock()
+	defer r.svcNodesMu.Unlock()
+
+	key := serviceKey{namespace: endpoints.Namespace, name: endpoints.Name}
+	delete(r.svcNodes, key)
+}
+
+func (r *nodeRegistry) handleEndpoints() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			endpoints, ok := obj.(*v1.Endpoints)
+			if !ok {
+				return
+			}
+			r.updateEndpointsNodes(endpoints)
+		},
+		UpdateFunc: func(_, obj interface{}) {
+			endpoints, ok := obj.(*v1.Endpoints)
+			if !ok {
+				return
+			}
+			r.updateEndpointsNodes(endpoints)
+		},
+		DeleteFunc: func(obj interface{}) {
+			if endpoints, ok := obj.(*v1.Endpoints); ok {
+				r.deleteEndpointsNodes(endpoints)
+				return
+			}
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				if endpoints, ok := tombstone.Obj.(*v1.Endpoints); ok {
+					r.deleteEndpointsNodes(endpoints)
+				}
+			}
+		},
+	}
+}
+
+func (r *nodeRegistry) nodesForService(svc *v1.Service) ([]nodeInfo, error) {
+	r.nodesMu.RLock()
+	defer r.nodesMu.RUnlock()
+
+	var nodes []nodeInfo
+
+	var filterValue string
+	if r.cs.config.Global.ServiceFilterLabel != "" {
+		filterValue, _ = getLabelOrAnnotation(svc.ObjectMeta, r.cs.config.Global.ServiceFilterLabel)
+	}
+
+	environment := r.cs.environmentForMeta(svc.ObjectMeta)
+	project, _ := r.cs.projectForMeta(svc.ObjectMeta, environment)
+
+	for _, nInfo := range r.nodes {
+		if nInfo.environmentID != environment {
+			continue
+		}
+		if filterValue != "" && nInfo.filterValue != filterValue {
+			continue
+		}
+		if project != "" && nInfo.projectID != project {
+			continue
+		}
+
+		nodes = append(nodes, *nInfo)
+	}
+
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no nodes available to add to service %s/%s", svc.Namespace, svc.Name)
+	}
+
+	return nodes, nil
+}
+
+func (r *nodeRegistry) idsForService(svc *v1.Service) (hostIDs []string, networkIDs []string, projectID string, err error) {
+	nodes, err := r.nodesForService(svc)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	hostIDs, networkIDs, projectID = idsForNodes(nodes)
+	return hostIDs, networkIDs, projectID, nil
+}
+
+func idsForNodes(nodes []nodeInfo) (hostIDs []string, networkIDs []string, projectID string) {
+	networkSet := sets.String{}
+
+	for _, nInfo := range nodes {
+		hostIDs = append(hostIDs, nInfo.vmID)
+		networkSet.Insert(nInfo.networkID)
+		projectID = nInfo.projectID
+	}
+
+	return hostIDs, networkSet.List(), projectID
+}
+
+func (r *nodeRegistry) updateNodes(nodes []*v1.Node) error {
+	if len(nodes) == 0 {
+		return errors.New("no nodes available to add to load balancer")
+	}
+
+	r.nodesMu.Lock()
+	defer r.nodesMu.Unlock()
+
+	r.revision++
+
+	visitedNodes := sets.String{}
+	for _, n := range nodes {
+		visitedNodes.Insert(n.Name)
+		if _, ok := r.nodes[n.Name]; ok {
+			err := r.nodes[n.Name].updateLabels(r.cs, n)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		nInfo, err := newNodeInfo(r.cs, n)
+		if err != nil {
+			return err
+		}
+		if nInfo == nil {
+			continue
+		}
+		nInfo.revision = r.revision
+		r.nodes[n.Name] = nInfo
+	}
+
+	toRemove := sets.StringKeySet(r.nodes).Difference(visitedNodes)
+	for k := range toRemove {
+		delete(r.nodes, k)
+	}
+
+	if len(r.nodes) == 0 {
+		return fmt.Errorf("unable to map kubernetes nodes to cloudstack instances for nodes: %v", nodeNames(nodes))
+	}
+
+	return nil
+}
+
+func (n *nodeInfo) updateLabels(cs *CSCloud, node *v1.Node) error {
+	n.environmentID = cs.environmentForMeta(node.ObjectMeta)
+
+	if cs.config.Global.NodeFilterLabel != "" {
+		n.filterValue, _ = getLabelOrAnnotation(node.ObjectMeta, cs.config.Global.NodeFilterLabel)
+	}
+
+	var err error
+	n.projectID, err = cs.projectForMeta(node.ObjectMeta, n.environmentID)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve projectID for node %#v: %v", node, err)
+	}
+
+	n.hostName = node.Name
+	if name, ok := getLabelOrAnnotation(node.ObjectMeta, cs.config.Global.NodeNameLabel); ok {
+		n.hostName = name
+	}
+
+	return nil
+}
+
+func newNodeInfo(cs *CSCloud, node *v1.Node) (*nodeInfo, error) {
+	nInfo := nodeInfo{
+		name: node.Name,
+	}
+
+	err := nInfo.updateLabels(cs, node)
+	if err != nil {
+		return nil, err
+	}
+
+	var manager *cloudstackManager
+	if env, ok := cs.environments[nInfo.environmentID]; ok {
+		manager = env.manager
+	}
+	if manager == nil {
+		return nil, fmt.Errorf("unable to retrieve cloudstack manager for environment %q", nInfo.environmentID)
+	}
+
+	vm, err := manager.virtualMachineByName(nInfo.hostName, nInfo.projectID)
+	if err != nil && err != ErrVMNotFound {
+		return nil, err
+	}
+	if err == ErrVMNotFound {
+		// Ignore nodes not found in cloudstack, they should be soon removed.
+		return nil, nil
+	}
+
+	nic, err := cs.externalNIC(vm)
+	if err != nil {
+		return nil, err
+	}
+
+	nInfo.vmID = vm.Id
+	nInfo.networkID = nic.Networkid
+
+	return &nInfo, nil
+}

--- a/cloudstack/nodes_test.go
+++ b/cloudstack/nodes_test.go
@@ -1,0 +1,751 @@
+package cloudstack
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cloudstackFake "github.com/tsuru/custom-cloudstack-ccm/cloudstack/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_NodeRegistry_updateNodes(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodes       []*corev1.Node
+		nodesAgain  []*corev1.Node
+		expected    map[string]*nodeInfo
+		expectedErr string
+		hook        func(*CSConfig) *CSConfig
+	}{
+		{
+			name:        "with nil nodes",
+			expectedErr: `no nodes available to add to load balancer`,
+			expected:    map[string]*nodeInfo{},
+		},
+		{
+			name:        "with empty nodes",
+			nodes:       []*corev1.Node{},
+			expectedErr: `no nodes available to add to load balancer`,
+			expected:    map[string]*nodeInfo{},
+		},
+		{
+			name: "with no nodes found in cloudstack",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "notfound",
+						Labels: map[string]string{
+							"my/project-label":  "11111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+			},
+			expectedErr: `unable to map kubernetes nodes to cloudstack instances for nodes: notfound`,
+			expected:    map[string]*nodeInfo{},
+		},
+		{
+			name: "with some nodes not found in cloudstack",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "notfound",
+						Labels: map[string]string{
+							"my/project-label":  "11111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"my/project-label":  "11111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+			},
+			expected: map[string]*nodeInfo{
+				"n1": {
+					name:          "n1",
+					vmID:          "vm1",
+					networkID:     "net1",
+					hostName:      "n1",
+					projectID:     "11111111-2222-3333-4444-555555555555",
+					environmentID: "env1",
+					filterValue:   "pool1",
+					revision:      1,
+				},
+			},
+		},
+		{
+			name: "with nodes found in cloudstack",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"my/project-label":  "11111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n2",
+						Labels: map[string]string{
+							"my/project-label":  "91111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool2",
+						},
+					},
+				},
+			},
+			expected: map[string]*nodeInfo{
+				"n1": {
+					name:          "n1",
+					vmID:          "vm1",
+					networkID:     "net1",
+					hostName:      "n1",
+					projectID:     "11111111-2222-3333-4444-555555555555",
+					environmentID: "env1",
+					filterValue:   "pool1",
+					revision:      1,
+				},
+				"n2": {
+					name:          "n2",
+					vmID:          "vm2",
+					networkID:     "net2",
+					hostName:      "n2",
+					projectID:     "91111111-2222-3333-4444-555555555555",
+					environmentID: "env1",
+					filterValue:   "pool2",
+					revision:      1,
+				},
+			},
+		},
+		{
+			name: "node with default project",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+			},
+			expected: map[string]*nodeInfo{
+				"n1": {
+					name:          "n1",
+					vmID:          "vm1",
+					networkID:     "net1",
+					hostName:      "n1",
+					projectID:     "def-proj1",
+					environmentID: "env1",
+					filterValue:   "pool1",
+					revision:      1,
+				},
+			},
+		},
+		{
+			name: "node with default environment",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"pool-label": "pool1",
+						},
+					},
+				},
+			},
+			expected: map[string]*nodeInfo{
+				"n1": {
+					name:          "n1",
+					vmID:          "vm1",
+					networkID:     "net1",
+					hostName:      "n1",
+					projectID:     "def-proj1",
+					environmentID: "env1",
+					filterValue:   "pool1",
+					revision:      1,
+				},
+			},
+		},
+		{
+			name: "node with empty filter value",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+					},
+				},
+			},
+			expected: map[string]*nodeInfo{
+				"n1": {
+					name:          "n1",
+					vmID:          "vm1",
+					networkID:     "net1",
+					hostName:      "n1",
+					projectID:     "def-proj1",
+					environmentID: "env1",
+					filterValue:   "",
+					revision:      1,
+				},
+			},
+		},
+		{
+			name: "node with multiple environments",
+			hook: func(cfg *CSConfig) *CSConfig {
+				cfg.Environment["env2"] = cfg.Environment["env1"]
+				cfg.Environment["env2"].ProjectID = "def-proj2"
+				return cfg
+			},
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+					},
+				},
+			},
+			expectedErr: `unable to retrieve projectID for node "n1" in environment "": no projectID found`,
+			expected:    map[string]*nodeInfo{},
+		},
+		{
+			name: "with existing nodes updating labels",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"my/project-label":  "11111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+			},
+			nodesAgain: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"my/project-label":  "91111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool2",
+						},
+					},
+				},
+			},
+			expected: map[string]*nodeInfo{
+				"n1": {
+					name:          "n1",
+					vmID:          "vm1",
+					networkID:     "net1",
+					hostName:      "n1",
+					projectID:     "91111111-2222-3333-4444-555555555555",
+					environmentID: "env1",
+					filterValue:   "pool2",
+					revision:      1,
+				},
+			},
+		},
+		{
+			name: "with new nodes in second call",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"my/project-label":  "11111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+			},
+			nodesAgain: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"my/project-label":  "11111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n2",
+						Labels: map[string]string{
+							"my/project-label":  "91111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool2",
+						},
+					},
+				},
+			},
+			expected: map[string]*nodeInfo{
+				"n1": {
+					name:          "n1",
+					vmID:          "vm1",
+					networkID:     "net1",
+					hostName:      "n1",
+					projectID:     "11111111-2222-3333-4444-555555555555",
+					environmentID: "env1",
+					filterValue:   "pool1",
+					revision:      1,
+				},
+				"n2": {
+					name:          "n2",
+					vmID:          "vm2",
+					networkID:     "net2",
+					hostName:      "n2",
+					projectID:     "91111111-2222-3333-4444-555555555555",
+					environmentID: "env1",
+					filterValue:   "pool2",
+					revision:      2,
+				},
+			},
+		},
+		{
+			name: "with fewer nodes in second call",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+						Labels: map[string]string{
+							"my/project-label":  "11111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n2",
+						Labels: map[string]string{
+							"my/project-label":  "91111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool2",
+						},
+					},
+				},
+			},
+			nodesAgain: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n2",
+						Labels: map[string]string{
+							"my/project-label":  "91111111-2222-3333-4444-555555555555",
+							"environment-label": "env1",
+							"pool-label":        "pool2",
+						},
+					},
+				},
+			},
+			expected: map[string]*nodeInfo{
+				"n2": {
+					name:          "n2",
+					vmID:          "vm2",
+					networkID:     "net2",
+					hostName:      "n2",
+					projectID:     "91111111-2222-3333-4444-555555555555",
+					environmentID: "env1",
+					filterValue:   "pool2",
+					revision:      1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := cloudstackFake.NewCloudstackServer()
+			defer srv.Close()
+			if tt.hook == nil {
+				tt.hook = func(cfg *CSConfig) *CSConfig { return cfg }
+			}
+			cs := newTestCSCloud(t, tt.hook(&CSConfig{
+				Global: globalConfig{
+					EnvironmentLabel:   "environment-label",
+					ProjectIDLabel:     "my/project-label",
+					NodeFilterLabel:    "pool-label",
+					ServiceFilterLabel: "pool-label",
+				},
+				Environment: map[string]*environmentConfig{
+					"env1": {
+						APIURL:          srv.URL,
+						APIKey:          "a",
+						SecretKey:       "b",
+						LBEnvironmentID: "1",
+						LBDomain:        "test.com",
+						ProjectID:       "def-proj1",
+					},
+				},
+			}), nil)
+
+			err := cs.nodeRegistry.updateNodes(tt.nodes)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.expectedErr)
+			}
+			if tt.nodesAgain != nil {
+				err = cs.nodeRegistry.updateNodes(tt.nodesAgain)
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, cs.nodeRegistry.nodes)
+		})
+	}
+}
+
+func Test_NodeRegistry_nodesContainingService(t *testing.T) {
+	tests := []struct {
+		name          string
+		endpoints     []corev1.Endpoints
+		nodes         []*corev1.Node
+		svc           serviceKey
+		expectedNodes []string
+	}{
+		{
+			name: "empty",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				},
+			},
+		},
+		{
+			name: "with svc key",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				},
+			},
+			svc: serviceKey{"ns1", "s1"},
+		},
+		{
+			name: "single svc pointing to node",
+			endpoints: []corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									NodeName: strPtr("n1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+					},
+				},
+			},
+			svc:           serviceKey{"ns1", "s1"},
+			expectedNodes: []string{"n1"},
+		},
+		{
+			name: "target svc in another namespace",
+			endpoints: []corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									NodeName: strPtr("n1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+					},
+				},
+			},
+			svc:           serviceKey{"ns2", "s1"},
+			expectedNodes: nil,
+		},
+		{
+			name: "endpoints poiting to multiple nodes",
+			endpoints: []corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									NodeName: strPtr("n1"),
+								},
+								{
+									NodeName: strPtr("n2"),
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s2"},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									NodeName: strPtr("n3"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n3",
+					},
+				},
+			},
+			svc:           serviceKey{"ns1", "s1"},
+			expectedNodes: []string{"n1", "n2"},
+		},
+		{
+			name: "endpoints poiting to invalid node",
+			endpoints: []corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									NodeName: strPtr("n1"),
+								},
+								{
+									NodeName: strPtr("n2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "n1",
+					},
+				},
+			},
+			svc:           serviceKey{"ns1", "s1"},
+			expectedNodes: []string{"n1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := cloudstackFake.NewCloudstackServer()
+			defer srv.Close()
+			cs := newTestCSCloud(t, &CSConfig{
+				Global: globalConfig{
+					EnvironmentLabel:   "environment-label",
+					ProjectIDLabel:     "my/project-label",
+					NodeFilterLabel:    "pool-label",
+					ServiceFilterLabel: "pool-label",
+				},
+				Environment: map[string]*environmentConfig{
+					"env1": {
+						APIURL:          srv.URL,
+						APIKey:          "a",
+						SecretKey:       "b",
+						LBEnvironmentID: "1",
+						LBDomain:        "test.com",
+						ProjectID:       "default-proj",
+					},
+				},
+			}, nil)
+
+			err := cs.nodeRegistry.updateNodes(tt.nodes)
+			require.NoError(t, err)
+			for _, ep := range tt.endpoints {
+				cs.nodeRegistry.updateEndpointsNodes(&ep)
+			}
+			result := cs.nodeRegistry.nodesContainingService(tt.svc)
+			var nodeNames []string
+			for _, n := range result {
+				nodeNames = append(nodeNames, n.name)
+			}
+			sort.Strings(nodeNames)
+			sort.Strings(tt.expectedNodes)
+			assert.Equal(t, tt.expectedNodes, nodeNames)
+		})
+	}
+}
+
+func Test_NodeRegistry_nodesForService(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodes         []*corev1.Node
+		svc           *corev1.Service
+		expectedNodes []string
+		expectedErr   string
+	}{
+		{
+			name: "empty",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				},
+			},
+			expectedErr: "service cannot be nil",
+		},
+		{
+			name: "svc with no labels",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				},
+			},
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc1"},
+			},
+			expectedNodes: []string{"n1"},
+		},
+		{
+			name: "svc filtering by environment, no matches",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				},
+			},
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "svc1",
+					Labels: map[string]string{
+						"environment-label": "env2",
+					},
+				},
+			},
+			expectedErr: "no nodes available to add to service ns1/svc1",
+		},
+		{
+			name: "svc filtering by project",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n2", Labels: map[string]string{
+						"my/project-label": "p9",
+					}},
+				},
+			},
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "svc1",
+					Labels: map[string]string{
+						"my/project-label": "p9",
+					},
+				},
+			},
+			expectedNodes: []string{"n2"},
+		},
+		{
+			name: "svc filtering by filterValue",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "n2", Labels: map[string]string{
+						"pool-label": "p1",
+					}},
+				},
+			},
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "svc1",
+					Labels: map[string]string{
+						"pool-label": "p1",
+					},
+				},
+			},
+			expectedNodes: []string{"n2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := cloudstackFake.NewCloudstackServer()
+			defer srv.Close()
+			cs := newTestCSCloud(t, &CSConfig{
+				Global: globalConfig{
+					EnvironmentLabel:   "environment-label",
+					ProjectIDLabel:     "my/project-label",
+					NodeFilterLabel:    "pool-label",
+					ServiceFilterLabel: "pool-label",
+				},
+				Environment: map[string]*environmentConfig{
+					"env1": {
+						APIURL:          srv.URL,
+						APIKey:          "a",
+						SecretKey:       "b",
+						LBEnvironmentID: "1",
+						LBDomain:        "test.com",
+						ProjectID:       "default-proj",
+					},
+				},
+			}, nil)
+
+			err := cs.nodeRegistry.updateNodes(tt.nodes)
+			require.NoError(t, err)
+			result, err := cs.nodeRegistry.nodesForService(tt.svc)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.expectedErr)
+			}
+			var nodeNames []string
+			for _, n := range result {
+				nodeNames = append(nodeNames, n.name)
+			}
+			sort.Strings(nodeNames)
+			sort.Strings(tt.expectedNodes)
+			assert.Equal(t, tt.expectedNodes, nodeNames)
+		})
+	}
+}
+
+func strPtr(v string) *string {
+	return &v
+}

--- a/cloudstack/service_queue.go
+++ b/cloudstack/service_queue.go
@@ -19,7 +19,8 @@ const (
 	promNamespace = "csccm"
 	promSubsystem = "update_lb_queue"
 
-	eventReasonUpdateFailed = "UpdateLoadBalancerFailed"
+	eventReasonUpdateFailed  = "QueuedUpdateLoadBalancerFailed"
+	eventReasonUpdateSuccess = "QueuedUpdatedLoadBalancer"
 )
 
 var (
@@ -217,6 +218,8 @@ func (q *updateLBNodeQueue) start(ctx context.Context) {
 					failuresTotal.WithLabelValues(item.service.Namespace, item.service.Name).Inc()
 					q.cs.recorder.Event(item.service, corev1.EventTypeWarning, eventReasonUpdateFailed, msg)
 					q.pushWithBackoff(item, defaultFailureBackoff)
+				} else {
+					q.cs.recorder.Event(item.service, corev1.EventTypeNormal, eventReasonUpdateSuccess, "Updated load balancer with new hosts")
 				}
 			}
 		}()

--- a/cloudstack/service_queue.go
+++ b/cloudstack/service_queue.go
@@ -1,0 +1,164 @@
+package cloudstack
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+const (
+	defaultUpdateLBWorkers = 5
+
+	promNamespace = "csccm"
+	promSubsystem = "update_lb_queue"
+
+	eventReasonUpdateFailed = "UpdateLoadBalancerFailed"
+)
+
+var (
+	processedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "processed_total",
+		Help:      "The number of processed queue items",
+	}, []string{"namespace", "service"})
+
+	failuresTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "failures_total",
+		Help:      "The number of failed queue items",
+	}, []string{"namespace", "service"})
+
+	processedDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "item_duration_seconds",
+		Help:      "The duration of the last processed queue item",
+	}, []string{"namespace", "service"})
+)
+
+type serviceNodeQueue struct {
+	sync.Mutex
+	cs    *CSCloud
+	queue map[serviceKey]queueEntry
+}
+
+type queueEntry struct {
+	service *v1.Service
+	nodes   []*v1.Node
+	start   time.Time
+}
+
+func (q *serviceNodeQueue) Upsert(service *v1.Service, nodes []*v1.Node) {
+	q.Lock()
+	defer q.Unlock()
+
+	if q.queue == nil {
+		q.queue = map[serviceKey]queueEntry{}
+	}
+
+	key := serviceKey{
+		namespace: service.Namespace,
+		name:      service.Name,
+	}
+
+	if entry, ok := q.queue[key]; ok {
+		entry.nodes = nodes
+		return
+	}
+
+	q.queue[key] = queueEntry{
+		service: service.DeepCopy(),
+		nodes:   nodes,
+		start:   time.Now(),
+	}
+}
+
+func (q *serviceNodeQueue) Pop() (queueEntry, bool, error) {
+	q.Lock()
+	defer q.Unlock()
+
+	for k, v := range q.queue {
+		delete(q.queue, k)
+		return v, true, nil
+	}
+
+	return queueEntry{}, false, nil
+}
+
+func (cs *CSCloud) startLBUpdateQueue(ctx context.Context) *serviceNodeQueue {
+	workers := cs.config.Global.UpdateLBWorkers
+	if workers == 0 {
+		workers = defaultUpdateLBWorkers
+	}
+	var queue serviceNodeQueue
+	for i := 0; i < workers; i++ {
+		go func() {
+			waitCh := time.After(0)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-waitCh:
+				}
+
+				item, ok, err := queue.Pop()
+				if err != nil {
+					klog.Errorf("unable to pop item from queue: %v", err)
+					continue
+				}
+
+				if !ok {
+					waitCh = time.After(time.Second)
+					continue
+				}
+
+				err = cs.processQueueEntry(item)
+				processedTotal.WithLabelValues(item.service.Namespace, item.service.Name).Inc()
+				processedDuration.WithLabelValues(item.service.Namespace, item.service.Name).Set(time.Since(item.start).Seconds())
+				if err != nil {
+					failuresTotal.WithLabelValues(item.service.Namespace, item.service.Name).Inc()
+					cs.recorder.Eventf(item.service, corev1.EventTypeWarning, eventReasonUpdateFailed, "Error updating load balancer with new hosts %v: %v", nodeNames(item.nodes), err)
+				}
+			}
+		}()
+	}
+	return &queue
+}
+
+func (cs *CSCloud) processQueueEntry(entry queueEntry) error {
+	cs.svcLock.Lock(entry.service)
+	defer cs.svcLock.Unlock(entry.service)
+
+	entry.nodes = cs.filterNodesMatchingLabels(entry.nodes, entry.service)
+
+	hostIDs, networkIDs, projectID, err := cs.extractIDs(entry.nodes)
+	if err != nil {
+		return err
+	}
+
+	// Get the load balancer details and existing rules.
+	lb, err := cs.getLoadBalancer(entry.service, projectID, networkIDs)
+	if err != nil {
+		return err
+	}
+
+	if lb.rule == nil {
+		return nil
+	}
+
+	err = shouldManageLB(lb)
+	if err != nil {
+		klog.V(3).Infof("Skipping UpdateLoadBalancer for service %s/%s: %v", entry.service.Namespace, entry.service.Name, err)
+		return nil
+	}
+
+	return lb.syncNodes(hostIDs, networkIDs)
+}

--- a/cloudstack/service_queue.go
+++ b/cloudstack/service_queue.go
@@ -46,19 +46,33 @@ var (
 
 type serviceNodeQueue struct {
 	sync.Mutex
-	cs    *CSCloud
-	queue map[serviceKey]queueEntry
+	cs     *CSCloud
+	queue  map[serviceKey]queueEntry
+	doneWG sync.WaitGroup
+	stopCh chan struct{}
 }
 
 type queueEntry struct {
 	service *v1.Service
-	nodes   []*v1.Node
+	nodes   []nodeInfo
 	start   time.Time
 }
 
-func (q *serviceNodeQueue) Upsert(service *v1.Service, nodes []*v1.Node) {
+func newServiceNodeQueue(cs *CSCloud) *serviceNodeQueue {
+	return &serviceNodeQueue{
+		cs:    cs,
+		queue: map[serviceKey]queueEntry{},
+	}
+}
+
+func (q *serviceNodeQueue) upsert(service *v1.Service) error {
 	q.Lock()
 	defer q.Unlock()
+
+	nodes, err := q.cs.nodeRegistry.nodesForService(service)
+	if err != nil {
+		return err
+	}
 
 	if q.queue == nil {
 		q.queue = map[serviceKey]queueEntry{}
@@ -69,80 +83,102 @@ func (q *serviceNodeQueue) Upsert(service *v1.Service, nodes []*v1.Node) {
 		name:      service.Name,
 	}
 
-	if entry, ok := q.queue[key]; ok {
-		entry.nodes = nodes
-		return
-	}
-
 	q.queue[key] = queueEntry{
-		service: service.DeepCopy(),
+		service: service,
 		nodes:   nodes,
 		start:   time.Now(),
 	}
+
+	return nil
 }
 
-func (q *serviceNodeQueue) Pop() (queueEntry, bool, error) {
+func (q *serviceNodeQueue) pop() (queueEntry, bool, error) {
 	q.Lock()
 	defer q.Unlock()
 
-	for k, v := range q.queue {
-		delete(q.queue, k)
-		return v, true, nil
+	topRevision := uint64(0)
+	var topSvcKey, emptySvcKey serviceKey
+
+	for svcKey := range q.queue {
+		svcNodes := q.cs.nodeRegistry.nodesContainingService(svcKey)
+		if topSvcKey == emptySvcKey {
+			topSvcKey = svcKey
+		}
+		for _, node := range svcNodes {
+			if node.revision > topRevision {
+				topRevision = node.revision
+				topSvcKey = svcKey
+			}
+		}
 	}
 
-	return queueEntry{}, false, nil
+	if topSvcKey == emptySvcKey {
+		return queueEntry{}, false, nil
+	}
+
+	entry := q.queue[topSvcKey]
+	delete(q.queue, topSvcKey)
+	return entry, true, nil
 }
 
-func (cs *CSCloud) startLBUpdateQueue(ctx context.Context) *serviceNodeQueue {
-	workers := cs.config.Global.UpdateLBWorkers
+func (q *serviceNodeQueue) stopWait() {
+	close(q.stopCh)
+	q.doneWG.Wait()
+}
+
+func (q *serviceNodeQueue) start(ctx context.Context) {
+	workers := q.cs.config.Global.UpdateLBWorkers
 	if workers == 0 {
 		workers = defaultUpdateLBWorkers
 	}
-	var queue serviceNodeQueue
+	q.stopCh = make(chan struct{})
 	for i := 0; i < workers; i++ {
+		q.doneWG.Add(1)
 		go func() {
+			defer q.doneWG.Done()
 			waitCh := time.After(0)
+			exitWhenDone := false
 			for {
 				select {
 				case <-ctx.Done():
 					return
+				case <-q.stopCh:
+					exitWhenDone = true
 				case <-waitCh:
 				}
 
-				item, ok, err := queue.Pop()
+				item, ok, err := q.pop()
 				if err != nil {
 					klog.Errorf("unable to pop item from queue: %v", err)
 					continue
 				}
 
 				if !ok {
+					if exitWhenDone {
+						return
+					}
 					waitCh = time.After(time.Second)
 					continue
 				}
 
-				err = cs.processQueueEntry(item)
+				err = q.cs.processQueueEntry(item)
 				processedTotal.WithLabelValues(item.service.Namespace, item.service.Name).Inc()
 				processedDuration.WithLabelValues(item.service.Namespace, item.service.Name).Set(time.Since(item.start).Seconds())
 				if err != nil {
 					failuresTotal.WithLabelValues(item.service.Namespace, item.service.Name).Inc()
-					cs.recorder.Eventf(item.service, corev1.EventTypeWarning, eventReasonUpdateFailed, "Error updating load balancer with new hosts %v: %v", nodeNames(item.nodes), err)
+					q.cs.recorder.Eventf(item.service, corev1.EventTypeWarning, eventReasonUpdateFailed, "Error updating load balancer with new hosts %v: %v", item.nodes, err)
+					q.upsert(item.service)
 				}
 			}
 		}()
 	}
-	return &queue
 }
 
 func (cs *CSCloud) processQueueEntry(entry queueEntry) error {
 	cs.svcLock.Lock(entry.service)
 	defer cs.svcLock.Unlock(entry.service)
 
-	entry.nodes = cs.filterNodesMatchingLabels(entry.nodes, entry.service)
-
-	hostIDs, networkIDs, projectID, err := cs.extractIDs(entry.nodes)
-	if err != nil {
-		return err
-	}
+	hostIDs, networkIDs, projectID := idsForNodes(entry.nodes)
 
 	// Get the load balancer details and existing rules.
 	lb, err := cs.getLoadBalancer(entry.service, projectID, networkIDs)

--- a/cloudstack/service_queue_test.go
+++ b/cloudstack/service_queue_test.go
@@ -1,0 +1,179 @@
+package cloudstack
+
+import (
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cloudstackFake "github.com/tsuru/custom-cloudstack-ccm/cloudstack/fake"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func preparePopTest(t *testing.T) (*CSCloud, func()) {
+	srv := cloudstackFake.NewCloudstackServer()
+	cs := newTestCSCloud(t, &CSConfig{
+		Global: globalConfig{
+			EnvironmentLabel:   "environment-label",
+			ProjectIDLabel:     "my/project-label",
+			NodeFilterLabel:    "pool-label",
+			ServiceFilterLabel: "pool-label",
+		},
+		Environment: map[string]*environmentConfig{
+			"env1": {
+				APIURL:          srv.URL,
+				APIKey:          "a",
+				SecretKey:       "b",
+				LBEnvironmentID: "1",
+				LBDomain:        "test.com",
+				ProjectID:       "def-proj1",
+			},
+		},
+	}, nil)
+
+	nodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "n2"},
+		},
+	}
+	err := cs.nodeRegistry.updateNodes(nodes)
+	require.NoError(t, err)
+
+	nodes = []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "n2"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "n3"},
+		},
+	}
+	err = cs.nodeRegistry.updateNodes(nodes)
+	require.NoError(t, err)
+
+	endpoints := []corev1.Endpoints{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
+			Subsets: []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{
+						{
+							NodeName: strPtr("n1"),
+						},
+						{
+							NodeName: strPtr("n2"),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s2"},
+			Subsets: []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{
+						{
+							NodeName: strPtr("n1"),
+						},
+						{
+							NodeName: strPtr("n3"),
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s3"},
+			Subsets: []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{
+						{
+							NodeName: strPtr("n2"),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, ep := range endpoints {
+		cs.nodeRegistry.updateEndpointsNodes(&ep)
+	}
+
+	err = cs.updateLBQueue.upsert(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s3"},
+	})
+	require.NoError(t, err)
+	err = cs.updateLBQueue.upsert(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s2"},
+	})
+	require.NoError(t, err)
+	err = cs.updateLBQueue.upsert(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
+	})
+	require.NoError(t, err)
+
+	return cs, srv.Close
+}
+
+func Test_serviceNodeQueue_pop(t *testing.T) {
+	cs, cleanup := preparePopTest(t)
+	defer cleanup()
+
+	entry, ok, err := cs.updateLBQueue.pop()
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "s2", entry.service.Name)
+
+	entry, ok, err = cs.updateLBQueue.pop()
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "s3", entry.service.Name)
+
+	entry, ok, err = cs.updateLBQueue.pop()
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "s1", entry.service.Name)
+
+	_, ok, err = cs.updateLBQueue.pop()
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func Test_serviceNodeQueue_pop_race(t *testing.T) {
+	cs, cleanup := preparePopTest(t)
+	defer cleanup()
+
+	nGoroutines := 10
+
+	entries := make(chan string, nGoroutines)
+	wg := sync.WaitGroup{}
+	for i := 0; i < nGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			entry, ok, err := cs.updateLBQueue.pop()
+			require.NoError(t, err)
+			if ok {
+				entries <- entry.service.Name
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(entries)
+	var strEntries []string
+	for e := range entries {
+		strEntries = append(strEntries, e)
+	}
+
+	sort.Strings(strEntries)
+	assert.Equal(t, []string{"s1", "s2", "s3"}, strEntries)
+}

--- a/cloudstack/service_queue_test.go
+++ b/cloudstack/service_queue_test.go
@@ -127,17 +127,17 @@ func Test_serviceNodeQueue_upsert_pop(t *testing.T) {
 	cs, cleanup := preparePopTest(t)
 	defer cleanup()
 
-	err := cs.updateLBQueue.upsert(&v1.Service{
+	err := cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s3"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
-	err = cs.updateLBQueue.upsert(&v1.Service{
+	err = cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s2"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
-	err = cs.updateLBQueue.upsert(&v1.Service{
+	err = cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
 
 	entry, ok, err := cs.updateLBQueue.pop()
@@ -164,21 +164,21 @@ func Test_serviceNodeQueue_upsertWithBackoff_pop(t *testing.T) {
 	cs, cleanup := preparePopTest(t)
 	defer cleanup()
 
-	err := cs.updateLBQueue.upsert(&v1.Service{
+	err := cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s3"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
-	err = cs.updateLBQueue.upsertWithBackoff(&v1.Service{
+	err = cs.updateLBQueue.pushWithBackoff(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s2"},
-	}, time.Second)
+	}, start: time.Now()}, 500*time.Millisecond)
 	require.NoError(t, err)
-	err = cs.updateLBQueue.upsert(&v1.Service{
+	err = cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
-	err = cs.updateLBQueue.upsert(&v1.Service{
+	err = cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s4"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
 
 	entry, ok, err := cs.updateLBQueue.pop()
@@ -200,11 +200,11 @@ func Test_serviceNodeQueue_upsertWithBackoff_pop(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(time.Second)
 
 	entry, ok, err = cs.updateLBQueue.pop()
 	require.NoError(t, err)
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.Equal(t, "s2", entry.service.Name)
 }
 
@@ -212,17 +212,17 @@ func Test_serviceNodeQueue_pop_race(t *testing.T) {
 	cs, cleanup := preparePopTest(t)
 	defer cleanup()
 
-	err := cs.updateLBQueue.upsert(&v1.Service{
+	err := cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s3"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
-	err = cs.updateLBQueue.upsert(&v1.Service{
+	err = cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s2"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
-	err = cs.updateLBQueue.upsert(&v1.Service{
+	err = cs.updateLBQueue.push(queueEntry{service: &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "s1"},
-	})
+	}, start: time.Now()})
 	require.NoError(t, err)
 
 	nGoroutines := 10

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/prometheus/client_golang v0.9.4 // indirect
+	github.com/prometheus/client_golang v0.9.4
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -538,6 +538,7 @@ k8s.io/component-base v0.0.0-20191016111234-b8c37ee0c266/go.mod h1:zT8T6A3K4wLlb
 k8s.io/cri-api v0.0.0-20190817025403-3ae76f584e79/go.mod h1:MQf3sTYxPlSVy4QhUrDFfHWFxHtwhdpvGBECKGhZULk=
 k8s.io/csi-translation-lib v0.0.0-20191016115443-72c16c0ea390/go.mod h1:0K9sZACh8VfA/3CUERb7P3g09UU+zRplb1Fh6Kx+ngc=
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/heapster v1.2.0-beta.1 h1:lUsE/AHOMHpi3MLlBEkaU8Esxm5QhdyCrv1o7ot0s84=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=

--- a/go.sum
+++ b/go.sum
@@ -33,7 +33,6 @@ github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:
 github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/bazelbuild/bazel-gazelle v0.0.0-20181012220611-c728ce9f663e/go.mod h1:uHBSeeATKpVazAACZBDPL/Nk/UhQDDsJWDlqYJo8/Us=
 github.com/bazelbuild/buildtools v0.0.0-20180226164855-80c7f0d45d7e/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
-github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -75,7 +74,6 @@ github.com/cpuguy83/go-md2man v1.0.4/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dY
 github.com/cyphar/filepath-securejoin v0.0.0-20170720062807-ae69057f2299/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v0.0.0-20170829104524-6e570ed0a266/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -148,7 +146,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/validate v0.17.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
-github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -304,7 +301,6 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -337,7 +333,6 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/seccomp/libseccomp-golang v0.0.0-20150813023252-1b506fc7c24e/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20151028001915-10ef21a441db/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sigma/go-inotify v0.0.0-20181102212354-c87b6cf5033d/go.mod h1:stlh9OsqBQSdwxTxX73mu41BBtRbIpZLQ7flcAoxAfo=
-github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -446,7 +441,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v9p/3ea4Rz+nnM5K/i4=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -508,9 +502,7 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -538,7 +530,6 @@ k8s.io/component-base v0.0.0-20191016111234-b8c37ee0c266/go.mod h1:zT8T6A3K4wLlb
 k8s.io/cri-api v0.0.0-20190817025403-3ae76f584e79/go.mod h1:MQf3sTYxPlSVy4QhUrDFfHWFxHtwhdpvGBECKGhZULk=
 k8s.io/csi-translation-lib v0.0.0-20191016115443-72c16c0ea390/go.mod h1:0K9sZACh8VfA/3CUERb7P3g09UU+zRplb1Fh6Kx+ngc=
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/heapster v1.2.0-beta.1 h1:lUsE/AHOMHpi3MLlBEkaU8Esxm5QhdyCrv1o7ot0s84=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=


### PR DESCRIPTION
This PR introduces concurrent worker goroutines responsible for updating existing load balancers with new hosts. Theses workers are managed by a queue that gives priority to services which have pod endpoints on the most recently seen nodes. This should improve the latency between a new node being added to the cluster and its LBs start using it.